### PR TITLE
mark notifications read automatically

### DIFF
--- a/app/controllers/api/connections_controller.rb
+++ b/app/controllers/api/connections_controller.rb
@@ -203,7 +203,7 @@ class Api::ConnectionsController < ApiController
 
     private
     def check_class_exists
-        unless SkillClass.find_by(id: params[:id])
+        unless SkillClass.visible_to_all.find_by(id: params[:id])
             error = {"error": "Class with that id does not exist"}
             render(json: error, status: 400)
         end

--- a/app/controllers/api/connections_controller.rb
+++ b/app/controllers/api/connections_controller.rb
@@ -47,7 +47,6 @@ class Api::ConnectionsController < ApiController
     end
 
     def update_match
-        logger = Rails.logger
 
         if @request.status_is_pending?
             

--- a/app/controllers/api/connections_controller.rb
+++ b/app/controllers/api/connections_controller.rb
@@ -47,6 +47,7 @@ class Api::ConnectionsController < ApiController
     end
 
     def update_match
+        logger = Rails.logger
 
         if @request.status_is_pending?
             
@@ -101,7 +102,7 @@ class Api::ConnectionsController < ApiController
                         end
                     else
                         # Shouldn't happen, notification not found
-                        puts "Error: there was no notification"
+                        logger.warn "Error: there was no notification"
                     end
 
                     if @request.status_is_accepted?

--- a/app/controllers/api/ratings_controller.rb
+++ b/app/controllers/api/ratings_controller.rb
@@ -12,10 +12,8 @@ class Api::RatingsController < ApiController
             # We need to mark the own user's notification as read, should there be one
             own_notification = Notification.find_by(match_id: @connection.match_id, person_id: @current_user.id, notification_type: "connection_closed")
                     
-            if own_notification
-                unless own_notification.update(read: true)
-                    return render_json_500(own_notification.errors.full_messages)
-                end
+            if own_notification and ! own_notification.update(read: true)
+                return render_json_500(own_notification.errors.full_messages)
             end
 
             res = {"review": review.as_json(only: [:id, :rating, :comment])}

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -7,4 +7,16 @@ class ApiController < ActionController::API
             render(json: error, status: 401)
         end
     end
+
+    private
+    def render_json_400(message)
+        error = {"error": message}
+        render(json: error, status: 400)
+    end
+
+    private
+    def render_json_500(message)
+        error = {"error": message}
+        render(json: error, status: 500)
+    end
 end

--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -8,7 +8,7 @@ class ConnectionsController < ApplicationController
         # connections where user a student
         student_connections = Connection.where(match_id: MatchRequest.where(student_id: @current_user.id), class_status: "in_progress").order(created_at: :desc)
         # connections where user is a teacher
-        teacher_connections = Connection.where(match_id: MatchRequest.where(skill_class_id: SkillClass.where(teacher_id: @current_user.id)), class_status: "in_progress").order(created_at: :desc)
+        teacher_connections = Connection.where(match_id: MatchRequest.where(skill_class_id: SkillClass.visible_to_all.where(teacher_id: @current_user.id)), class_status: "in_progress").order(created_at: :desc)
 
         # json payload should contain information about the other person, so should contain info about the user
         # when user is a student and vice-versa

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -13,7 +13,7 @@
 class Connection < ApplicationRecord
   belongs_to :match, class_name: 'MatchRequest', foreign_key: 'match_id'
 
-  has_many :reviews
+  has_many :reviews, dependent: :destroy
 
   # class status [in progress, given, cancelled]
   enum class_status: {

--- a/app/models/match_request.rb
+++ b/app/models/match_request.rb
@@ -24,7 +24,7 @@ class MatchRequest < ApplicationRecord
   belongs_to :skill_class, class_name: 'SkillClass', foreign_key: 'skill_class_id'
 
   has_many :notifications, foreign_key: 'match_id', dependent: :destroy
-  has_one :connection, foreign_key: 'match_id'
+  has_one :connection, foreign_key: 'match_id', dependent: :destroy
 
   # status [pending, accepted, refused, cancelled]
   enum status: {

--- a/app/models/skill_class.rb
+++ b/app/models/skill_class.rb
@@ -16,11 +16,15 @@
 #  skill_id       :bigint           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  deleted        :boolean          default(FALSE)
 #
 class SkillClass < ApplicationRecord
   belongs_to :teacher, class_name: 'User', foreign_key: 'teacher_id'
   belongs_to :skill
   has_many :match_requests, foreign_key: 'class_id'
+
+  scope :visible_to_all, -> { where(deleted: false, archived: false) }
+  scope :visible_to_own_user, -> { where(deleted: false) }
   
   # method [synchronous, asynchronous, both]
   enum method: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   get '/api/classes/:id', to: 'api/classes#get_single_class', as: 'get_single_class'
   post '/api/users/:id/classes', to: 'api/classes#post_class', as: 'post_class'
   get '/api/users/:id/classes', to: 'api/classes#get_user_classes', as: 'get_user_classes'
+  put '/api/users/:id/classes/:class_id', to: 'api/classes#update_class', as: 'update_class'
+  delete '/api/users/:id/classes/:class_id', to: 'api/classes#delete_class', as: 'delete_class'
 
   #Connections
   post '/api/classes/:id/request', to: 'api/connections#request_match', as: 'request_match'

--- a/db/migrate/20210813145431_add_deleted_field_to_skill_class.rb
+++ b/db/migrate/20210813145431_add_deleted_field_to_skill_class.rb
@@ -1,0 +1,5 @@
+class AddDeletedFieldToSkillClass < ActiveRecord::Migration[6.1]
+  def change
+    add_column :skill_classes, :deleted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_11_143051) do
+ActiveRecord::Schema.define(version: 2021_08_13_145431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2021_08_11_143051) do
     t.bigint "skill_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "deleted", default: false
     t.index ["skill_id"], name: "index_skill_classes_on_skill_id"
     t.index ["teacher_id"], name: "index_skill_classes_on_teacher_id"
   end

--- a/test/fixtures/skill_classes.yml
+++ b/test/fixtures/skill_classes.yml
@@ -16,6 +16,7 @@
 #  skill_id       :bigint           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  deleted        :boolean          default(FALSE)
 #
 
 one:

--- a/test/models/skill_class_test.rb
+++ b/test/models/skill_class_test.rb
@@ -16,6 +16,7 @@
 #  skill_id       :bigint           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  deleted        :boolean          default(FALSE)
 #
 require "test_helper"
 


### PR DESCRIPTION
This PR fixes a couple of errors, where delete on cascade was not defined for connections and reviews and the wrong user was being notified when a connections was ended.
This PR also allows the respective notifications to be marked as read when a user answers a match request or when a user reviews a class that was closed by the other party.
