### PR TITLE
Update and delete a user's class

### DIFF
--- a/app/controllers/api/classes_controller.rb
+++ b/app/controllers/api/classes_controller.rb
@@ -27,8 +27,7 @@ class Api::ClassesController < ApiController
 
     def get_classes
         if @current_user
-            # TODO filters
-            classes = SkillClass.where(archived: false).where(class_params())
+            classes = SkillClass.where(archived: false, deleted: false).where(class_params())
             classes = classes.as_json(only: [:id, :title, :description, :no_classes, :class_duration, :method, :regime, :location], include: {skill: { only: [:id, :name]}, teacher: {only: [:id, :username, :name]}})
             render(json: classes)
         else
@@ -40,7 +39,7 @@ class Api::ClassesController < ApiController
     def get_new_classes
         # Classes created up to a week ago
         if @current_user
-            classes = SkillClass.where(archived: false).where("created_at >= ?", 1.week.ago)
+            classes = SkillClass.where(archived: false, deleted: false).where("created_at >= ?", 1.week.ago).where(class_params())
             classes = classes.as_json(only: [:id, :title, :description, :no_classes, :class_duration, :method, :regime, :location], include: {skill: { only: [:id, :name]}, teacher: {only: [:id, :username, :name]}})
             render(json: classes)
         else
@@ -54,10 +53,10 @@ class Api::ClassesController < ApiController
 
             if @current_user.id == params[:id].to_i
                 #own classes, show all classes
-                classes = SkillClass.where(teacher: params[:id])
+                classes = SkillClass.where(teacher: params[:id], deleted: false)
             else
                 #someone else's classes, only show those not archived
-                classes = SkillClass.where(teacher: params[:id], archived: false)
+                classes = SkillClass.where(teacher: params[:id], archived: false, deleted: false)
             end
             
             classes = classes.as_json(only: [:id, :title, :description, :no_classes, :class_duration, :method, :regime, :location], include: {skill: { only: [:id, :name]}, teacher: {only: [:id, :username, :name]}})
@@ -71,7 +70,7 @@ class Api::ClassesController < ApiController
     def get_single_class
         if @current_user
 
-            c = SkillClass.find_by(id: params[:id])
+            c = SkillClass.find_by(id: params[:id], deleted: false)
 
             if c
 
@@ -124,7 +123,7 @@ class Api::ClassesController < ApiController
 
     private
     def check_class
-        @skill_class = SkillClass.find_by(id: params[:class_id])
+        @skill_class = SkillClass.find_by(id: params[:class_id], deleted: false)
 
         return render_json_400("Class with that id was not found") unless @skill_class
         

--- a/app/controllers/api/classes_controller.rb
+++ b/app/controllers/api/classes_controller.rb
@@ -27,7 +27,7 @@ class Api::ClassesController < ApiController
 
     def get_classes
         if @current_user
-            classes = SkillClass.where(archived: false, deleted: false).where(class_params())
+            classes = SkillClass.visible_to_all.where(class_params())
             classes = classes.as_json(only: [:id, :title, :description, :no_classes, :class_duration, :method, :regime, :location], include: {skill: { only: [:id, :name]}, teacher: {only: [:id, :username, :name]}})
             render(json: classes)
         else
@@ -39,7 +39,7 @@ class Api::ClassesController < ApiController
     def get_new_classes
         # Classes created up to a week ago
         if @current_user
-            classes = SkillClass.where(archived: false, deleted: false).where("created_at >= ?", 1.week.ago).where(class_params())
+            classes = SkillClass.visible_to_all.where("created_at >= ?", 1.week.ago).where(class_params())
             classes = classes.as_json(only: [:id, :title, :description, :no_classes, :class_duration, :method, :regime, :location], include: {skill: { only: [:id, :name]}, teacher: {only: [:id, :username, :name]}})
             render(json: classes)
         else
@@ -53,10 +53,10 @@ class Api::ClassesController < ApiController
 
             if @current_user.id == params[:id].to_i
                 #own classes, show all classes
-                classes = SkillClass.where(teacher: params[:id], deleted: false)
+                classes = SkillClass.visible_to_own_user.where(teacher: params[:id])
             else
                 #someone else's classes, only show those not archived
-                classes = SkillClass.where(teacher: params[:id], archived: false, deleted: false)
+                classes = SkillClass.visible_to_all.where(teacher: params[:id])
             end
             
             classes = classes.as_json(only: [:id, :title, :description, :no_classes, :class_duration, :method, :regime, :location], include: {skill: { only: [:id, :name]}, teacher: {only: [:id, :username, :name]}})
@@ -70,7 +70,7 @@ class Api::ClassesController < ApiController
     def get_single_class
         if @current_user
 
-            c = SkillClass.find_by(id: params[:id], deleted: false)
+            c = SkillClass.visible_to_all.find_by(id: params[:id])
 
             if c
 
@@ -123,7 +123,7 @@ class Api::ClassesController < ApiController
 
     private
     def check_class
-        @skill_class = SkillClass.find_by(id: params[:class_id], deleted: false)
+        @skill_class = SkillClass.visible_to_all.find_by(id: params[:class_id])
 
         return render_json_400("Class with that id was not found") unless @skill_class
         

--- a/app/controllers/api/classes_controller.rb
+++ b/app/controllers/api/classes_controller.rb
@@ -1,6 +1,6 @@
 class Api::ClassesController < ApiController
     include AuthenticationConcern
-    before_action :check_class, only: [:update_class]
+    before_action :check_class, only: [:update_class, :delete_class]
   
     def post_class
 
@@ -103,6 +103,22 @@ class Api::ClassesController < ApiController
             end
         rescue
             render_json_400("Method or regime is not valid")
+        end
+    end
+
+    def delete_class
+        open_connections = Connection.where(class_status: "in_progress", match_id: MatchRequest.where(skill_class_id: @skill_class.id))
+        
+        if open_connections.empty?
+            # we can delete the class
+            @skill_class.update(deleted: true)
+
+            res = {"success": "Class was deleted successfully"}
+            render(json: res)
+
+        else
+            # There are open connections so class can't be closed
+            render_json_400("Class can't be deleted because there are open connections to it")
         end
     end
 

--- a/app/controllers/api/connections_controller.rb
+++ b/app/controllers/api/connections_controller.rb
@@ -203,7 +203,7 @@ class Api::ConnectionsController < ApiController
 
     private
     def check_class_exists
-        unless SkillClass.find_by(id: params[:id], deleted: false)
+        unless SkillClass.visible_to_all.find_by(id: params[:id])
             error = {"error": "Class with that id does not exist"}
             render(json: error, status: 400)
         end

--- a/app/controllers/api/connections_controller.rb
+++ b/app/controllers/api/connections_controller.rb
@@ -203,7 +203,7 @@ class Api::ConnectionsController < ApiController
 
     private
     def check_class_exists
-        unless SkillClass.find_by(id: params[:id])
+        unless SkillClass.find_by(id: params[:id], deleted: false)
             error = {"error": "Class with that id does not exist"}
             render(json: error, status: 400)
         end

--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -8,7 +8,7 @@ class ConnectionsController < ApplicationController
         # connections where user a student
         student_connections = Connection.where(match_id: MatchRequest.where(student_id: @current_user.id), class_status: "in_progress").order(created_at: :desc)
         # connections where user is a teacher
-        teacher_connections = Connection.where(match_id: MatchRequest.where(skill_class_id: SkillClass.where(teacher_id: @current_user.id, deleted: false)), class_status: "in_progress").order(created_at: :desc)
+        teacher_connections = Connection.where(match_id: MatchRequest.where(skill_class_id: SkillClass.visible_to_all.where(teacher_id: @current_user.id)), class_status: "in_progress").order(created_at: :desc)
 
         # json payload should contain information about the other person, so should contain info about the user
         # when user is a student and vice-versa

--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -8,7 +8,7 @@ class ConnectionsController < ApplicationController
         # connections where user a student
         student_connections = Connection.where(match_id: MatchRequest.where(student_id: @current_user.id), class_status: "in_progress").order(created_at: :desc)
         # connections where user is a teacher
-        teacher_connections = Connection.where(match_id: MatchRequest.where(skill_class_id: SkillClass.where(teacher_id: @current_user.id)), class_status: "in_progress").order(created_at: :desc)
+        teacher_connections = Connection.where(match_id: MatchRequest.where(skill_class_id: SkillClass.where(teacher_id: @current_user.id, deleted: false)), class_status: "in_progress").order(created_at: :desc)
 
         # json payload should contain information about the other person, so should contain info about the user
         # when user is a student and vice-versa

--- a/app/models/skill_class.rb
+++ b/app/models/skill_class.rb
@@ -16,6 +16,7 @@
 #  skill_id       :bigint           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  deleted        :boolean          default(FALSE)
 #
 class SkillClass < ApplicationRecord
   belongs_to :teacher, class_name: 'User', foreign_key: 'teacher_id'

--- a/app/models/skill_class.rb
+++ b/app/models/skill_class.rb
@@ -22,6 +22,9 @@ class SkillClass < ApplicationRecord
   belongs_to :teacher, class_name: 'User', foreign_key: 'teacher_id'
   belongs_to :skill
   has_many :match_requests, foreign_key: 'class_id'
+
+  scope :visible_to_all, -> { where(deleted: false, archived: false) }
+  scope :visible_to_own_user, -> { where(deleted: false) }
   
   # method [synchronous, asynchronous, both]
   enum method: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   get '/api/classes/:id', to: 'api/classes#get_single_class', as: 'get_single_class'
   post '/api/users/:id/classes', to: 'api/classes#post_class', as: 'post_class'
   get '/api/users/:id/classes', to: 'api/classes#get_user_classes', as: 'get_user_classes'
+  put '/api/users/:id/classes/:class_id', to: 'api/classes#update_class', as: 'update_class'
+  delete '/api/users/:id/classes/:class_id', to: 'api/classes#delete_class', as: 'delete_class'
 
   #Connections
   post '/api/classes/:id/request', to: 'api/connections#request_match', as: 'request_match'

--- a/db/migrate/20210813145431_add_deleted_field_to_skill_class.rb
+++ b/db/migrate/20210813145431_add_deleted_field_to_skill_class.rb
@@ -1,0 +1,5 @@
+class AddDeletedFieldToSkillClass < ActiveRecord::Migration[6.1]
+  def change
+    add_column :skill_classes, :deleted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_11_143051) do
+ActiveRecord::Schema.define(version: 2021_08_13_145431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2021_08_11_143051) do
     t.bigint "skill_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "deleted", default: false
     t.index ["skill_id"], name: "index_skill_classes_on_skill_id"
     t.index ["teacher_id"], name: "index_skill_classes_on_teacher_id"
   end

--- a/test/fixtures/skill_classes.yml
+++ b/test/fixtures/skill_classes.yml
@@ -16,6 +16,7 @@
 #  skill_id       :bigint           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  deleted        :boolean          default(FALSE)
 #
 
 one:

--- a/test/models/skill_class_test.rb
+++ b/test/models/skill_class_test.rb
@@ -16,6 +16,7 @@
 #  skill_id       :bigint           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  deleted        :boolean          default(FALSE)
 #
 require "test_helper"
 


### PR DESCRIPTION
This PR enables user to edit or delete a certain class of their own. A user can edit all properties except for the skill that is taught. A class can only be deleted if there are no current classes being give, i.e., if there are no open ("in_progress") connections.
To maintain all references valid in the database, when deleting a class, all the match requests, connections and reviews would also have to be deleted, so to avoid that (since we don't want to lose a user's reviews), a "deleted" field was added to the SkilLClass table, to be set to true instead of acutally deleting the record.